### PR TITLE
Exception in the method SqlScriptExecutor.Log #138

### DIFF
--- a/src/DbUp/Support/SqlServer/SqlScriptExecutor.cs
+++ b/src/DbUp/Support/SqlServer/SqlScriptExecutor.cs
@@ -180,7 +180,7 @@ namespace DbUp.Support.SqlServer
                 int totalLength = 0;
                 for (int i = 0; i < reader.FieldCount; i++)
                 {
-                    int maxLength = lines.Max(l => (l[i] ?? "").Length) + 2;
+                    int maxLength = (lines.Count == 0 ? 0 : lines.Max(l => (l[i] ?? "").Length)) + 2;
                     format += " {" + i + ", " + maxLength + "} |";
                     totalLength += (maxLength + 3);
                 }


### PR DESCRIPTION
Fixed issue https://github.com/DbUp/DbUp/issues/138 (method Log doesn't work with empty result)
